### PR TITLE
Improve semantic analysis for compiler

### DIFF
--- a/comun.h
+++ b/comun.h
@@ -1,0 +1,37 @@
+// Common definitions and prototypes
+
+#ifndef COMUN_H
+#define COMUN_H
+#include <vector>
+
+const int ERRLEXICO=1,
+          ERRSINT=2,
+          ERREOF=3,
+          ERRLEXEOF=4,
+
+          ERR_YADECL=5,
+          ERR_NODECL=6,
+          ERR_NOCABE=7,
+
+          ERR_IFWHILE=8,
+          ERR_LOOP=9,
+
+          ERR_DIM=10,
+          ERR_FALTAN=11,
+          ERR_SOBRAN=12,
+          ERR_INDICE_ENTERO=13,
+
+          ERR_ASIG=14,
+          ERR_MAXTEMP=15;
+
+void errorSemantico(int nerror,int fila,int columna,const char *s);
+void msgError(int nerror,int nlin,int ncol,const char *s);
+
+typedef struct {int fil; int col;} Pos;
+typedef struct {char *nombre; int fil; int col;} IdInfo;
+typedef struct {int val; int fil; int col;} NumIntInfo;
+typedef struct {double val; int fil; int col;} NumRealInfo;
+typedef struct {char op; int fil; int col;} OpInfo;
+struct ListIndices { std::vector<unsigned> tipos; std::vector<Pos> seps; };
+
+#endif

--- a/plp5.l
+++ b/plp5.l
@@ -1,0 +1,87 @@
+%{
+#include "comun.h"
+#include "plp5.tab.h"
+#include <string.h>
+#include <stdlib.h>
+
+int numlin = 1;
+int numcol = 1;
+int tokline = 1;
+int tokcol = 1;
+%}
+
+%x COMMENT
+
+%%
+"/*"                { BEGIN(COMMENT); }
+<COMMENT>"*/"        { BEGIN(INITIAL); }
+<COMMENT>\n          { numlin++; numcol = 1; }
+<COMMENT>.           { /* ignore comment */ }
+
+[ \t]+              { numcol += yyleng; }
+\n                   { numlin++; numcol = 1; }
+
+"fn"                 { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_FN; }
+"endfn"              { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_ENDFN; }
+"int"                { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_INT; }
+"real"               { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_REAL; }
+"array"              { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_ARRAY; }
+"blq"                { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_BLQ; }
+"fblq"               { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_FBLQ; }
+"let"                { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_LET; }
+"var"                { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_VAR; }
+"print"              { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_PRINT; }
+"read"               { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_READ; }
+"if"                 { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_IF; }
+"else"               { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_ELSE; }
+"elif"               { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_ELIF; }
+"fi"                 { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_FI; }
+"while"              { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_WHILE; }
+"loop"               { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_LOOP; }
+"range"              { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_RANGE; }
+"endloop"            { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_ENDLOOP; }
+
+","                  { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_COMA; }
+";"                  { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_PYC; }
+":"                  { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_DOSP; }
+"("                  { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_PARI; }
+")"                  { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_PARD; }
+"+"|"-"             { tokline=numlin; tokcol=numcol; yylval.opi.op = yytext[0]; yylval.opi.fil=numlin; yylval.opi.col=numcol; numcol+=yyleng; return TK_OPAS; }
+"*"|"/"             { tokline=numlin; tokcol=numcol; yylval.opi.op = yytext[0]; yylval.opi.fil=numlin; yylval.opi.col=numcol; numcol+=yyleng; return TK_OPMD; }
+"="                  { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_ASIG; }
+"["                  { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_CORI; }
+"]"                  { tokline=numlin; tokcol=numcol; yylval.pos.fil=numlin; yylval.pos.col=numcol; numcol+=yyleng; return TK_CORD; }
+
+[0-9]+               {
+                        tokline=numlin; tokcol=numcol;
+                        yylval.numi.val = atoi(yytext);
+                        yylval.numi.fil=numlin; yylval.numi.col=numcol;
+                        numcol+=yyleng;
+                        return TK_NUMINT;
+                     }
+[0-9]+"."[0-9]+      {
+                        tokline=numlin; tokcol=numcol;
+                        yylval.numr.val = atof(yytext);
+                        yylval.numr.fil=numlin; yylval.numr.col=numcol;
+                        numcol+=yyleng;
+                        return TK_NUMREAL;
+                     }
+[A-Za-z][0-9A-Za-z]* {
+                        tokline=numlin; tokcol=numcol;
+                        yylval.id.nombre = strdup(yytext);
+                        yylval.id.fil=numlin; yylval.id.col=numcol;
+                        numcol+=yyleng;
+                        return TK_ID;
+                     }
+
+.                    {
+                        char s[2]={yytext[0],0};
+                        msgError(ERRLEXICO,numlin,numcol,s);
+                     }
+
+<<EOF>>              {
+                        return 0;
+                     }
+%%
+
+int yywrap(){ return 1; }


### PR DESCRIPTION
## Summary
- implement position-aware token structures in `comun.h`
- extend lexer to record line and column for tokens
- implement parser semantics with symbol table checks and basic type validation
- allow semicolon separated instruction lists
- added helper functions for type size and base type handling

## Testing
- `make`
- `bash autocorrector-plp5.sh` *(fails: 8 tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_684fe9c7fab48321b1f8b0608cf85c96